### PR TITLE
Fix internal server error in button component

### DIFF
--- a/src/lib/components/ui/button/button.svelte
+++ b/src/lib/components/ui/button/button.svelte
@@ -21,8 +21,8 @@
 	class={cn(buttonVariants({ variant, size, className }))}
 	type="button"
 	{...$$restProps}
-	on:click|passive
-	on:keydown|passive
+	on:click
+	on:keydown
 >
 	<slot />
 </ButtonPrimitive.Root>


### PR DESCRIPTION
Related to #7

Removes unsupported event modifiers in `button.svelte` to fix internal server error.
- Removes `on:click|passive` and `on:keydown|passive` modifiers from `ButtonPrimitive.Root` in `src/lib/components/ui/button/button.svelte`, resolving the internal server error caused by unsupported event modifiers.
- Replaces them with standard `on:click` and `on:keydown` event handlers without modifiers, ensuring compatibility with Svelte's event handling.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/burggraf/shadcn-test/issues/7?shareId=5758dfd0-7ea5-4d7f-9945-b6e1413afaf8).